### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/cer0531/d23bab95-80e4-4e56-ad74-81ce01f14203/210eb42f-8e11-45e8-bc04-2b52b4a16764/_apis/work/boardbadge/5a469549-5110-4225-a65d-1478b2ec25c3)](https://dev.azure.com/cer0531/d23bab95-80e4-4e56-ad74-81ce01f14203/_boards/board/t/210eb42f-8e11-45e8-bc04-2b52b4a16764/Microsoft.RequirementCategory)
 A Github Pages template for academic websites. This was forked (then detached) by [Stuart Geiger](https://github.com/staeiou) from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/), which is © 2016 Michael Rose and released under the MIT License. See LICENSE.md.
 
 I think I've got things running smoothly and fixed some major bugs, but feel free to file issues or make pull requests if you want to improve the generic template / theme.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/cer0531/d23bab95-80e4-4e56-ad74-81ce01f14203/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.