### PR TITLE
Move Bargum to alumni; fix GitHub Pages build errors

### DIFF
--- a/_pages/lab.md
+++ b/_pages/lab.md
@@ -17,7 +17,6 @@ These new technologies correspond to the full stack of Web 3.0 and can be applie
 
 - [Ömer Emin Çınar, Assistant Professor, Visiting Erasmus+ KA131 academic mobility fellow](https://www.linkedin.com/in/omeremincinar/)
 - [Razvan Paisa, Postdoc, upcoming Enterprise Audio AI Expert](https://www.linkedin.com/in/razvan-paisa-23a865a6/)
-- [Anders R Bargum: Industrial PhD Student at Heka VR](https://www.linkedin.com/in/anders-bargum-b887a81a7/)
 - [Tony Thai Do: MSc, Certified Azure Specialist, ollama and RAG tamer](https://www.linkedin.com/in/tony-thai-do)
 - [Mubarik Jamal Muuse: TA in SPIS, overall Edge AI wizard](https://www.linkedin.com/in/mubarik-jamal-muuse-9b98b1342/)
 
@@ -32,6 +31,7 @@ These new technologies correspond to the full stack of Web 3.0 and can be applie
 
 # alumni
 
+- [Anders R Bargum: Industrial PhD Student at Heka VR](https://www.linkedin.com/in/anders-bargum-b887a81a7/)
 - [Ganga Katwal: Lab intern, Multimedia Design, Digital Marketing, Motion Graphics](https://www.linkedin.com/in/ganga-katwal-1a0197206/ "Intern1")
 - [Martin S Bivolov: Lab intern, Reinforcement Learning, Motion Sensors, Stroke Rehabilitation](https://www.linkedin.com/in/martin-bivolov-10bb8b188/ "Intern2")
 


### PR DESCRIPTION
## Summary
- Move Anders Bargum from members to alumni on the /lab/ page.
- Add `.nojekyll` at the repo root: `_config.yml`'s `keep_files` only preserves it if present, but it never existed in the repo, so `gh-pages` never got one. Without it, GitHub Pages retries its own restricted Jekyll build on top of the already-built static site and fails every time (Pages API `status: "errored"` on every recent build), even though the deploy Action itself succeeds.

Note: the "student projects" iframe on /lab/ still won't render for visitors — the linked OneDrive share (`1drv.ms/...`) returns "The request is blocked" for anonymous requests, which points to a OneDrive link-sharing permission issue, not something fixable in this repo. Flagging for follow-up outside this PR.

## Test plan
- [ ] Confirm `Deploy site` Action succeeds on merge
- [ ] Confirm GitHub Pages build status moves from `errored` to `built` after merge (`gh api repos/cerkut/cerkut.github.io/pages`)
- [ ] Visually check https://cerkut.github.io/lab/ shows Bargum under alumni