### PR TITLE
Link MED5/MED7 supervision entries to their RefWorks bib records

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "jekyll-serve",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-lc",
+        "eval \"$(rbenv init -)\"; LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 bundle exec jekyll serve --host 0.0.0.0"
+      ],
+      "port": 4000
+    }
+  ]
+}

--- a/_pages/med5.md
+++ b/_pages/med5.md
@@ -11,7 +11,7 @@ nav: false
 
 > Frandsen, M. — Medialogy, Master, (Master Programme) 2. semester, 2026
 >
-> #Spatial Audio, Haptic Feedback, Term paper — <a href="{{ '/theses/' | relative_url }}#frandsen" title="@report{RefWorks:frandsen2026multimodal,&#10;  author = {Frandsen, Marios},&#10;  title = {Multimodal Feedback In Virtual Reality: Evaluating the effect of spatial audio and haptic feedback on task performance, cognitive load and immersion.},&#10;  year = {2026},&#10;}">(Frandsen, 2026)</a>
+> #Spatial Audio, Haptic Feedback, Term paper — <a href="/theses/#frandsen" title="@report{RefWorks:frandsen2026multimodal,&#10;  author = {Frandsen, Marios},&#10;  title = {Multimodal Feedback In Virtual Reality: Evaluating the effect of spatial audio and haptic feedback on task performance, cognitive load and immersion.},&#10;  year = {2026},&#10;}">(Frandsen, 2026)</a>
 
 #### Multimodal Looper: Interactive Visual Music through Gestures
 

--- a/_pages/med5.md
+++ b/_pages/med5.md
@@ -7,6 +7,12 @@ nav: false
 
 ## Immersive Installations
 
+#### Multimodal Feedback In Virtual Reality: Evaluating the effect of spatial audio and haptic feedback on task performance, cognitive load and immersion
+
+> Frandsen, M. — Medialogy, Master, (Master Programme) 2. semester, 2026
+>
+> #Spatial Audio, Haptic Feedback, Term paper — <a href="{{ '/theses/' | relative_url }}#frandsen" title="@report{RefWorks:frandsen2026multimodal,&#10;  author = {Frandsen, Marios},&#10;  title = {Multimodal Feedback In Virtual Reality: Evaluating the effect of spatial audio and haptic feedback on task performance, cognitive load and immersion.},&#10;  year = {2026},&#10;}">(Frandsen, 2026)</a>
+
 #### Multimodal Looper: Interactive Visual Music through Gestures
 
 > Kiliboz, P. — Medialogy, Master, (Master Programme) 4. term, 2023

--- a/_pages/med7.md
+++ b/_pages/med7.md
@@ -9,7 +9,7 @@ nav: false
 
 > Hansen K. — Sound and Music Computing, (Master Programme) 4. Term, 2026
 >
-> #Neural Audio Synthesis, Sound Matching, Student thesis
+> #Neural Audio Synthesis, Sound Matching, Student thesis — <a href="{{ '/theses/' | relative_url }}#sound2serum" title="@mscthesis{RefWorks:hansen2026sound2serum,&#10;  author = {Hansen, Kevin Thor},&#10;  title = {Sound2Serum - Neural Sound Matching System for Serum 2},&#10;  year = {2026},&#10;}">(Hansen, 2026)</a>
 
 #### FirstImpress: LLM-Powered Multi-Agent Interview System
 

--- a/_pages/med7.md
+++ b/_pages/med7.md
@@ -9,7 +9,7 @@ nav: false
 
 > Hansen K. — Sound and Music Computing, (Master Programme) 4. Term, 2026
 >
-> #Neural Audio Synthesis, Sound Matching, Student thesis — <a href="{{ '/theses/' | relative_url }}#sound2serum" title="@mscthesis{RefWorks:hansen2026sound2serum,&#10;  author = {Hansen, Kevin Thor},&#10;  title = {Sound2Serum - Neural Sound Matching System for Serum 2},&#10;  year = {2026},&#10;}">(Hansen, 2026)</a>
+> #Neural Audio Synthesis, Sound Matching, Student thesis — <a href="/theses/#sound2serum" title="@mscthesis{RefWorks:hansen2026sound2serum,&#10;  author = {Hansen, Kevin Thor},&#10;  title = {Sound2Serum - Neural Sound Matching System for Serum 2},&#10;  year = {2026},&#10;}">(Hansen, 2026)</a>
 
 #### FirstImpress: LLM-Powered Multi-Agent Interview System
 


### PR DESCRIPTION
Point the Frandsen and Sound2Serum project entries at their export.bib records on the theses page, using this theme's search-hash filtering (bibsearch.js) rather than jekyll-scholar's {% cite %} anchor links, since the latter link to the raw bib key which never appears in the rendered text and gets swallowed by the live search filter. Also add a native title tooltip with the BibTeX for a quick hover preview, and a .claude/launch.json for previewing the site with the browser tools.

## Summary

Describe what changed and why.

> **Adding your site to the showcase?** We no longer accept pull requests for that. Please close this PR and post a request in the _Showcase_ category of [GitHub Discussions](https://github.com/alshedivat/al-folio/discussions) instead — entries are reviewed and added periodically.

## Ownership Routing

- [ ] I confirmed this PR targets the correct repo based on `docs/BOUNDARIES.md`.
- [ ] This PR only changes starter-owned scope (`al-folio`) **or** I am porting a routed change and linked the owning repo issue/PR.

Owning repo (if not starter): <!-- e.g., al-org-dev/al-folio-core -->
Related issue/PR: <!-- link -->

## Plugin Ecosystem (if applicable)

- [ ] Not applicable
- [ ] This PR proposes a plugin for **featured-only** listing.
- [ ] This PR proposes a plugin for **bundled** starter inclusion.

If plugin-related, provide:

- Plugin repo URL:
- Gem name:
- Jekyll plugin id:
- Compatibility (`al_folio_min`/`al_folio_max`):
- Demo page/post path:
- Maintainer contact:

## Starter Wiring Changes

- [ ] Not applicable
- [ ] Updated `Gemfile` dependency wiring.
- [ ] Updated `_config.yml` plugin activation/config.
- [ ] Updated `_data/featured_plugins.yml` metadata.

## Validation

- [ ] `npm ci`
- [ ] `bundle exec jekyll build`
- [ ] `npm run lint:prettier`
- [ ] `npm run lint:style-contract`
- [ ] Integration tests (`test/integration_*.sh`) as needed
- [ ] Visual tests (`npm run test:visual`) as needed

## Notes

Compatibility, migration implications, and follow-ups:
